### PR TITLE
Fix Capistrano autocompletion generating

### DIFF
--- a/plugins/capistrano/_capistrano
+++ b/plugins/capistrano/_capistrano
@@ -4,7 +4,7 @@
 if [[ -f config/deploy.rb || -f Capfile ]]; then
   if [[ ! -f .cap_tasks~ || config/deploy.rb -nt .cap_tasks~ ]]; then
     echo "\nGenerating .cap_tasks~..." > /dev/stderr
-    cap -v --tasks | grep '#' | cut -d " " -f 2 > .cap_tasks~
+    cap --tasks | grep '#' | cut -d " " -f 2 > .cap_tasks~
   fi
-  compadd `cat .cap_tasks~`
+  compdef `cat .cap_tasks~`
 fi


### PR DESCRIPTION
When -v is use, cap output only version instead tasks, so file .cap_tasks~ is empty.
Replace compass with compdef, because an error "compadd: can only be called from completion function" occured.
